### PR TITLE
fix: Reorder flags in command generators

### DIFF
--- a/pre_commit_dbt/dbt_run.py
+++ b/pre_commit_dbt/dbt_run.py
@@ -21,7 +21,7 @@ def prepare_cmd(
     global_flags = get_flags(global_flags)
     cmd_flags = get_flags(cmd_flags)
     dbt_models = paths_to_dbt_models(paths, prefix, postfix)
-    cmd = ["dbt", *global_flags, "run", "-m", *dbt_models, *cmd_flags]
+    cmd = ["dbt", *global_flags, "run", *cmd_flags, "-m", *dbt_models]
     return cmd
 
 

--- a/pre_commit_dbt/dbt_test.py
+++ b/pre_commit_dbt/dbt_test.py
@@ -21,7 +21,7 @@ def prepare_cmd(
     global_flags = get_flags(global_flags)
     cmd_flags = get_flags(cmd_flags)
     dbt_models = paths_to_dbt_models(paths, prefix, postfix)
-    cmd = ["dbt", *global_flags, "test", "-m", *dbt_models, *cmd_flags]
+    cmd = ["dbt", *global_flags, "test", *cmd_flags, "-m", *dbt_models]
     return cmd
 
 


### PR DESCRIPTION
I've updated the `dbt_run.py` and `dbt_test.py` scripts to move the `*cmd_flag` lists to be added to the `cmd` list prior to the model section. This will prevent misclassification of cmd_flags as being models by dbt in the event that we provide a --project-dir flag.